### PR TITLE
Updated symphony-api-client-node version used in node-bots templates.

### DIFF
--- a/generators/node-bots/templates/node/bots/dev-meetup-aws/package.json
+++ b/generators/node-bots/templates/node/bots/dev-meetup-aws/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "aws-sdk": "^2.346.0",
     "nba": "^4.5.0",
-    "symphony-api-client-node": "^1.0.4"
+    "symphony-api-client-node": "^1.0.11"
   }
 }

--- a/generators/node-bots/templates/node/bots/nlp-based/package.json
+++ b/generators/node-bots/templates/node/bots/nlp-based/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "compromise": "^11.5.3",
     "kew": "^0.7.0",
-    "symphony-api-client-node": "^1.0.4"
+    "symphony-api-client-node": "^1.0.11"
   }
 }

--- a/generators/node-bots/templates/node/bots/request-reply/package.json
+++ b/generators/node-bots/templates/node/bots/request-reply/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "symphony-api-client-node": "^1.0.4"
+    "symphony-api-client-node": "^1.0.11"
   }
 }


### PR DESCRIPTION
Updated symphony-api-client-node version used in node-bots templates in order to be able to use last changes in Nodejs SDK (for example for Symphony Elements or getMentions/Hashtags/Cashtags helpers)