### PR TITLE
PLAT-10310: Fail generation when Maven/Gradle build fails

### DIFF
--- a/generators/bdk/java/index.js
+++ b/generators/bdk/java/index.js
@@ -8,7 +8,7 @@ const axios = require('axios')
 const BASE_JAVA = 'src/main/java';
 const BASE_RESOURCES = 'src/main/resources';
 
-const BDK_VERSION_DEFAULT = '2.0.1';
+const BDK_VERSION_DEFAULT = '2.0.0';
 const SPRING_VERSION_DEFAULT = '2.4.1'
 
 module.exports = class extends Generator {

--- a/generators/bdk/java/index.js
+++ b/generators/bdk/java/index.js
@@ -8,7 +8,7 @@ const axios = require('axios')
 const BASE_JAVA = 'src/main/java';
 const BASE_RESOURCES = 'src/main/resources';
 
-const BDK_VERSION_DEFAULT = '2.0.0';
+const BDK_VERSION_DEFAULT = '2.0.1';
 const SPRING_VERSION_DEFAULT = '2.4.1'
 
 module.exports = class extends Generator {
@@ -139,12 +139,19 @@ module.exports = class extends Generator {
    * Build Maven or Gradle project
    */
   install() {
+    let buildResult;
+
     if (this.answers.build === 'Maven') {
       this.log('Running '.green.bold + './mvnw package'.white.bold + ' in your project'.green.bold);
-      this.spawnCommandSync(path.join(this.destinationPath(), 'mvnw'), ['package']);
+      buildResult = this.spawnCommandSync(path.join(this.destinationPath(), 'mvnw'), ['package']);
     } else {
       this.log('Running '.green.bold + './gradlew build'.white.bold + ' in your project'.green.bold);
-      this.spawnCommandSync(path.join(this.destinationPath(), 'gradlew'), ['build']);
+      buildResult = this.spawnCommandSync(path.join(this.destinationPath(), 'gradlew'), ['build']);
+    }
+
+    if (buildResult.status !== 0) {
+      this.log.error(buildResult.stderr);
+      this.env.error("Failed to build generated project");
     }
   }
 


### PR DESCRIPTION
### Ticket
PLAT-10310

### Description
The result of the Maven/Gradle execution was not checked when generating
a Java BDK 2.0 project.

This was preventing the tests to fail if the project is not building,
which is something we want to check (if it does not compile anymore or
if the dependency version is wrong).

This will cause the generator to fail if the JDK is missing for
instance which is something we want too IMHO.

### Dependencies
N/A

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [X] Public functions properly commented
