### PR TITLE
PLAT-10347: Invalid RSA keys are sometimes generated

### DIFF
--- a/generators/bdk/java/index.js
+++ b/generators/bdk/java/index.js
@@ -2,8 +2,7 @@ const Generator = require('yeoman-generator');
 const colors = require('colors');
 const path = require('path');
 const fs = require('fs');
-const keyPair = require('keypair');
-const axios = require('axios')
+const keyPair = require('../../lib/certificate-creator/rsa-certificate-creator').keyPair;
 
 const BASE_JAVA = 'src/main/java';
 const BASE_RESOURCES = 'src/main/resources';

--- a/generators/lib/certificate-creator/rsa-certificate-creator.js
+++ b/generators/lib/certificate-creator/rsa-certificate-creator.js
@@ -1,18 +1,34 @@
-const keypair = require('keypair');
+const forge = require('node-forge');
 const fs = require('fs');
 
 class RsaKeyPairCreator {
-    constructor(username) {
-        this.username = username;
-    }
+  constructor(username) {
+    this.username = username;
+  }
 
-    create() {
-        let pair = keypair({'bits': 4096});
-        const rsa_folder = 'rsa';
+  create() {
+    let pair = keyPair(4096)
 
-        fs.mkdirSync(rsa_folder)
-        fs.writeFileSync(rsa_folder + "/" + "rsa-public-" + this.username + ".pem", pair.public);
-        fs.writeFileSync(rsa_folder + "/" + "rsa-private-" + this.username + ".pem", pair.private);
-    }
+    const rsa_folder = 'rsa';
+    fs.mkdirSync(rsa_folder)
+    fs.writeFileSync(rsa_folder + "/" + "rsa-public-" + this.username + ".pem", pair.public);
+    fs.writeFileSync(rsa_folder + "/" + "rsa-private-" + this.username + ".pem", pair.private);
+  }
 }
+
+/**
+ * Return a RSA key pair in PEM format.
+ *
+ * @param size the size for the private key in bits.
+ * @returns {{private, public}} private and public key content in PEM format.
+ */
+function keyPair(size) {
+  let generated = forge.pki.rsa.generateKeyPair(size);
+  return {
+    private: forge.pki.privateKeyToPem(generated.privateKey),
+    public: forge.pki.publicKeyToRSAPublicKeyPem(generated.publicKey)
+  };
+}
+
 module.exports = RsaKeyPairCreator;
+module.exports.keyPair = keyPair;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "axios": "^0.21.1",
     "colors": "^1.3.3",
-    "keypair": "^1.0.1",
     "mkdirp": "^0.5.2",
     "node-forge": "^0.10.0",
     "node-openssl-p12": "^0.1.8",

--- a/test/java-bdk.spec.js
+++ b/test/java-bdk.spec.js
@@ -171,5 +171,5 @@ function assertKeyPair(generatedPrivateKey, generatedPublicKey) {
   let forgePrivateKey = forge.pki.privateKeyFromPem(generatedPrivateKey);
   let forgePublicKey = forge.pki.setRsaPublicKey(forgePrivateKey.n, forgePrivateKey.e);
   let publicKey = forge.pki.publicKeyToRSAPublicKeyPem(forgePublicKey).toString();
-  assert.textEqual(generatedPublicKey.split("\n").join(""), publicKey.split("\r\n").join(""))
+  assert.textEqual(generatedPublicKey.split("\n").join(""), publicKey.split("\n").join(""))
 }

--- a/test/lib/rsa-certificate-creator.test.js
+++ b/test/lib/rsa-certificate-creator.test.js
@@ -1,0 +1,16 @@
+const keyPair = require('../../generators/lib/certificate-creator/rsa-certificate-creator').keyPair;
+const forge = require('node-forge')
+const assert = require('yeoman-assert')
+
+
+test('keyPair generates public and private keys', () => {
+  let generated = keyPair(4096);
+
+  expect(generated.public).toMatch(/BEGIN RSA PUBLIC KEY/)
+  expect(generated.private).toMatch(/BEGIN RSA PRIVATE KEY/)
+
+  let forgePrivateKey = forge.pki.privateKeyFromPem(generated.private);
+  let forgePublicKey = forge.pki.setRsaPublicKey(forgePrivateKey.n, forgePrivateKey.e);
+  let publicKey = forge.pki.publicKeyToRSAPublicKeyPem(forgePublicKey).toString();
+  expect(generated.public.split("\n").join("")).toBe(publicKey.split("\n").join(""));
+});


### PR DESCRIPTION
### Ticket
PLAT-10347

### Description
RSA keys created by the generator were sometimes not accepted by the
BDK, failing with the error message:
java.lang.IllegalArgumentException: failed to construct sequence from byte[]: corrupted stream detected

While no obvious problems were found in the RSA keys themselves (checking them
with openssl command as1nparse), tests showed that out of 100 RSA
private keys, 16 were failing.

Changing the keypair library to use node-forge instead seems to fix
the problem. Besides node-forge is much faster, already used elsewhere
in the generator and keypair is no really maintained.

A new keypair shared function has been introduced, to replace the
library out of the box, minimizing the diff.

### Dependencies
None

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [X] Public functions properly commented
