### PR TITLE
PLAT-10544 : BDK2.0 Java - Update yeoman generator following 2.1.0 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ New feature requests on the legacy SDK will not be accepted.
 ## Module and package structure
 
 The code is structured into several generators inside the [generators folder](generators):
-* [2.0](generators/bdk) generating a bot and using the [Java BDK2.0](https://github.com/SymphonyPlatformSolutions/symphony-api-client-java);
+* [2.0](generators/bdk/java) generating a bot and using the [Java BDK2.0](https://github.com/SymphonyPlatformSolutions/symphony-api-client-java);
 * `*-bots` folders generating bots, using the [.NET](https://github.com/SymphonyPlatformSolutions/symphony-api-client-dotnet),
 [legacy java](https://github.com/SymphonyPlatformSolutions/symphony-api-client-java/tree/master/symphony-bdk-legacy/symphony-api-client-java),
 [node](https://github.com/SymphonyPlatformSolutions/symphony-api-client-node) and

--- a/generators/bdk/java/index.js
+++ b/generators/bdk/java/index.js
@@ -7,7 +7,7 @@ const keyPair = require('../../lib/certificate-creator/rsa-certificate-creator')
 const BASE_JAVA = 'src/main/java';
 const BASE_RESOURCES = 'src/main/resources';
 
-const BDK_VERSION_DEFAULT = '2.0.0';
+const BDK_VERSION_DEFAULT = '2.1.1';
 const SPRING_VERSION_DEFAULT = '2.4.1'
 
 // Make it configurable for faster test execution


### PR DESCRIPTION
### Ticket
[PLAT-10544](https://perzoinc.atlassian.net/browse/PLAT-10544)

### Description
In this PR, we changed Java bdk used release from 2.0.0 to 2.1.0
CONTRIBUTING readme updated to point java bot generating to generators/bdk/java as generators/bdk contains python as well

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [ ] Filled properly the description and dependencies, if any
- [ ] Public functions properly commented
