### PR TITLE
Revise Python BDK examples

### DIFF
--- a/generators/bdk/python/index.js
+++ b/generators/bdk/python/index.js
@@ -3,13 +3,13 @@ const keyPair = require('../../lib/certificate-creator/rsa-certificate-creator')
 const path = require('path');
 
 const KEY_PAIR_LENGTH = 'KEY_PAIR_LENGTH';
-const BDK_VERSION_DEFAULT = '2.0b2';
+const BDK_VERSION_DEFAULT = '2.0b3';
 
 const COMMON_TEMPLATE_FOLDER = '../../../common-template'
 const COMMON_EXT_APP_TEMPLATES = COMMON_TEMPLATE_FOLDER + '/circle-of-trust-ext-app'
 
 const RESOURCES_FOLDER = 'resources' // target resources folder
-const PYTHON_FOLDER = 'python' // target folder containing python sources
+const PYTHON_FOLDER = 'src' // target folder containing python sources
 
 
 module.exports = class extends Generator {
@@ -30,6 +30,10 @@ module.exports = class extends Generator {
     }
   }
 
+  install() {
+    this.spawnCommandSync('python3', [ '-m', 'venv', 'env' ]);
+  }
+
   end() {
     if (this.pair) {
       this.log('\nYou can now update the service account '.cyan +
@@ -40,8 +44,13 @@ module.exports = class extends Generator {
     }
 
     this.log(`Your Python project has been successfully generated !`.cyan.bold);
+    if (process.platform === "win32") {
+      this.log(`Activate virtual environment:`.cyan.bold + ' env\\Scripts\\activate.bat');
+    } else {
+      this.log(`Activate virtual environment:`.cyan.bold + ' source env/bin/activate');
+    }
     this.log(`Install all required packages with: `.cyan.bold + `pip3 install -r requirements.txt`);
-    this.log(`And run your bot with: `.cyan.bold + `python3 -m ${PYTHON_FOLDER}.main`);
+    this.log(`And run your bot with: `.cyan.bold + `python3 -m ${PYTHON_FOLDER}`);
   }
 
   _generateRsaKeys() {
@@ -60,8 +69,9 @@ module.exports = class extends Generator {
   _generateCommonFiles() {
     [
       ['requirements.txt.ejs', 'requirements.txt'],
-      ['logging.conf.ejs', 'logging.conf'],
+      ['logging.conf.ejs', RESOURCES_FOLDER + '/logging.conf'],
       ['.gitignore.tpl', '.gitignore'],
+      ['readme.md.ejs', 'readme.md'],
       [COMMON_TEMPLATE_FOLDER + '/truststore/all_symphony_certs.pem', RESOURCES_FOLDER + '/all_symphony_certs.pem']
     ].forEach(path_pair => {
       this.fs.copyTpl(
@@ -76,8 +86,8 @@ module.exports = class extends Generator {
     let bot_app_folder = 'bot-app';
     [
       [bot_app_folder + '/config.yaml.ejs', RESOURCES_FOLDER + '/config.yaml'],
-      [bot_app_folder + '/gif.xml.ejs', RESOURCES_FOLDER + '/gif.xml'],
-      [bot_app_folder + '/main.py.ejs', PYTHON_FOLDER + '/main.py'],
+      [bot_app_folder + '/gif.jinja2.ejs', RESOURCES_FOLDER + '/gif.jinja2'],
+      [bot_app_folder + '/__main__.py.ejs', PYTHON_FOLDER + '/__main__.py'],
       [bot_app_folder + '/activities.py.ejs', PYTHON_FOLDER + '/activities.py']
     ].forEach(path_pair => {
       this.fs.copyTpl(
@@ -100,7 +110,7 @@ module.exports = class extends Generator {
       [ext_app_folder + '/config.yaml.ejs', RESOURCES_FOLDER + '/config.yaml'],
       [ext_app_folder + '/srv.crt', RESOURCES_FOLDER + '/srv.crt'],
       [ext_app_folder + '/srv.key', RESOURCES_FOLDER + '/srv.key'],
-      [ext_app_folder + '/main.py.ejs', PYTHON_FOLDER + '/main.py'],
+      [ext_app_folder + '/__main__.py.ejs', PYTHON_FOLDER + '/__main__.py'],
       [ext_app_folder + '/ext_app_be.py.ejs', PYTHON_FOLDER + '/ext_app_be.py'],
       [ext_app_folder + '/config.yaml.ejs', RESOURCES_FOLDER + '/config.yaml']
     ].forEach(path_pair => {

--- a/generators/bdk/python/templates/.gitignore.tpl
+++ b/generators/bdk/python/templates/.gitignore.tpl
@@ -6,3 +6,7 @@
 .DS_Store
 
 rsa/
+env/
+bdk.log
+datafeed.id
+**/__pycache__

--- a/generators/bdk/python/templates/bot-app/__main__.py.ejs
+++ b/generators/bdk/python/templates/bot-app/__main__.py.ejs
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import asyncio
 import logging.config
-import os
+from pathlib import Path
 
 from symphony.bdk.core.activity.command import CommandContext
 from symphony.bdk.core.config.loader import BdkConfigLoader
@@ -10,27 +10,21 @@ from symphony.bdk.core.symphony_bdk import SymphonyBdk
 from symphony.bdk.gen.agent_model.v4_initiator import V4Initiator
 from symphony.bdk.gen.agent_model.v4_message_sent import V4MessageSent
 
-from python.activities import EchoCommandActivity, GreetUserJoinedActivity
-from python.gif_activities import GifSlashCommand, GifFormReplyActivity
+from .activities import EchoCommandActivity, GreetUserJoinedActivity
+from .gif_activities import GifSlashCommand, GifFormReplyActivity
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
-
-
-class RealTimeEventListenerImpl(RealTimeEventListener):
-
-    def __init__(self, bdk: SymphonyBdk):
-        self._bdk = bdk
-
-    async def on_message_sent(self, initiator: V4Initiator, event: V4MessageSent):
-        logging.debug("Message received from %s", initiator.user.display_name)
+# Configure logging
+current_dir = Path(__file__).parent.parent
+logging_conf = Path.joinpath(current_dir, 'resources', 'logging.conf')
+logging.config.fileConfig(logging_conf, disable_existing_loggers=False)
 
 
 async def run():
-    config = BdkConfigLoader.load_from_file(os.path.join(current_dir, '..', 'resources/config.yaml'))
+    config = BdkConfigLoader.load_from_file(Path.joinpath(current_dir, 'resources', 'config.yaml'))
 
     async with SymphonyBdk(config) as bdk:
         datafeed_loop = bdk.datafeed()
-        datafeed_loop.subscribe(RealTimeEventListenerImpl(bdk))
+        datafeed_loop.subscribe(MessageListener())
 
         activities = bdk.activities()
         activities.register(EchoCommandActivity(bdk.messages()))
@@ -40,18 +34,21 @@ async def run():
 
         @activities.slash("/hello")
         async def hello(context: CommandContext):
-            await bdk.messages().send_message(
-                context.stream_id,
-                f"<messageML>Hello {context.initiator.user.display_name}, hope you are doing well!</messageML>"
-            )
+            name = context.initiator.user.display_name
+            response = f"<messageML>Hello {name}, hope you are doing well!</messageML>"
+            await bdk.messages().send_message(context.stream_id, response)
 
-        logging.info("Start datafeed...")
+        # Start the datafeed read loop
         await datafeed_loop.start()
 
 
-logging.config.fileConfig(os.path.join(current_dir, '..', 'logging.conf'),
-                          disable_existing_loggers=False)
+class MessageListener(RealTimeEventListener):
+    async def on_message_sent(self, initiator: V4Initiator, event: V4MessageSent):
+        logging.debug("Message received from %s: %s",
+            initiator.user.display_name, event.message.message)
 
+
+# Start the main asyncio run
 try:
     logging.info("Running bot application...")
     asyncio.run(run())

--- a/generators/bdk/python/templates/bot-app/gif.jinja2.ejs
+++ b/generators/bdk/python/templates/bot-app/gif.jinja2.ejs
@@ -2,12 +2,9 @@
     <h2>Gif Generator</h2>
     <p>Requested by {{ name }}</p>
     <form id="gif-category-form">
-
         <text-field name="category" placeholder="Enter a Gif category..."/>
-
         <button name="submit" type="action">Submit</button>
         <button name="test" type="action">Test</button>
         <button type="reset">Reset Data</button>
-
     </form>
 </messageML>

--- a/generators/bdk/python/templates/bot-app/gif_activities.py.ejs
+++ b/generators/bdk/python/templates/bot-app/gif_activities.py.ejs
@@ -13,7 +13,7 @@ class GifSlashCommand(SlashCommandActivity):
     def __init__(self, messages: MessageService):
         super().__init__("/gif", False, self.display_gif_form)
         self._messages = messages
-        self.template = Template(open('resources/gif.jinja2').read())
+        self.template = Template(open('resources/gif.jinja2').read(), autoescape=True)
 
     async def display_gif_form(self, context: CommandContext):
         message = self.template.render(name=context.initiator.user.display_name)

--- a/generators/bdk/python/templates/bot-app/gif_activities.py.ejs
+++ b/generators/bdk/python/templates/bot-app/gif_activities.py.ejs
@@ -1,4 +1,6 @@
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+import os
+
+from jinja2 import Template
 
 from symphony.bdk.core.activity.command import SlashCommandActivity, CommandContext
 from symphony.bdk.core.activity.form import FormReplyActivity, FormReplyContext
@@ -6,16 +8,12 @@ from symphony.bdk.core.service.message.message_service import MessageService
 
 
 class GifSlashCommand(SlashCommandActivity):
-    """Sends a form when sending @bot-name /gif
-    """
+    # Sends a form when sending @bot-name /gif
 
     def __init__(self, messages: MessageService):
-        super().__init__("/gif", True, self.display_gif_form)
+        super().__init__("/gif", False, self.display_gif_form)
         self._messages = messages
-
-        env = Environment(loader=FileSystemLoader(['<%= resourcesFolder %>']),
-                          autoescape=select_autoescape(['html', 'xml']))
-        self.template = env.get_template('gif.xml')
+        self.template = Template(open('resources/gif.jinja2').read())
 
     async def display_gif_form(self, context: CommandContext):
         message = self.template.render(name=context.initiator.user.display_name)
@@ -23,16 +21,15 @@ class GifSlashCommand(SlashCommandActivity):
 
 
 class GifFormReplyActivity(FormReplyActivity):
-    """Sends back the selected value on form submission
-    """
+    # Sends back the selected value on form submission
 
     def __init__(self, messages: MessageService):
-        super().__init__()
         self._messages = messages
 
     def matches(self, context: FormReplyContext) -> bool:
-        return context.form_id == "gif-category-form" and context.form_values["action"] == "submit" and \
-               context.form_values["category"]
+        return context.form_id == "gif-category-form" \
+            and context.form_values["action"] == "submit" \
+            and context.form_values["category"]
 
     async def on_activity(self, context: FormReplyContext):
         category = context.form_values["category"]

--- a/generators/bdk/python/templates/ext-app/__main__.py.ejs
+++ b/generators/bdk/python/templates/ext-app/__main__.py.ejs
@@ -1,30 +1,30 @@
 #!/usr/bin/env python3
 import logging.config
-import os
 import ssl
+from pathlib import Path
 
 from aiohttp import web
 from symphony.bdk.core.config.loader import BdkConfigLoader
 
-from python.ext_app_be import CircleOfTrustService, CircleOfTrustHandler, APP_BASE_PATH
+from .ext_app_be import CircleOfTrustService, CircleOfTrustHandler, APP_BASE_PATH
 
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-RESOURCES_FOLDER = os.path.join(CURRENT_DIR, "../resources")
-STATIC_FOLDER = os.path.join(RESOURCES_FOLDER, "static")
+CURRENT_DIR = Path(__file__).parent.parent
+RESOURCES_FOLDER = Path.joinpath(CURRENT_DIR, "resources")
+STATIC_FOLDER = Path.joinpath(CURRENT_DIR, "static")
 
 def run_app():
     ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
     # Below are a self-signed certificate with its corresponding private key
     # Please update them when deploying in production
-    cert_file_path = os.path.join(RESOURCES_FOLDER, "srv.crt")
-    key_file_path = os.path.join(RESOURCES_FOLDER, "srv.key")
+    cert_file_path = Path.joinpath(RESOURCES_FOLDER, "srv.crt")
+    key_file_path = Path.joinpath(RESOURCES_FOLDER, "srv.key")
     ssl_context.load_cert_chain(cert_file_path, key_file_path)
 
     web.run_app(create_app(), ssl_context=ssl_context, port=10443)  # set the desired port to listen to
 
 
 def create_app():
-    config = BdkConfigLoader.load_from_file(os.path.join(RESOURCES_FOLDER, 'config.yaml'))
+    config = BdkConfigLoader.load_from_file(Path.joinpath(RESOURCES_FOLDER, 'config.yaml'))
     cot_service = CircleOfTrustService(config)
     cot_handler = CircleOfTrustHandler(cot_service)
 
@@ -38,6 +38,6 @@ def create_app():
     return app
 
 
-logging.config.fileConfig(os.path.join(RESOURCES_FOLDER, '..', 'logging.conf'), disable_existing_loggers=False)
+logging.config.fileConfig(Path.joinpath(RESOURCES_FOLDER, 'logging.conf'), disable_existing_loggers=False)
 
 run_app()

--- a/generators/bdk/python/templates/readme.md.ejs
+++ b/generators/bdk/python/templates/readme.md.ejs
@@ -1,0 +1,17 @@
+# Sample BDK 2.0 for Python project
+This is a sample bot project using the Symphony BDK 2.0 for Python.
+To get started, follow these commands below:
+
+## First run only:
+1. Create virtual environment:
+    - `python3 -m venv env`
+2. Install dependencies:
+    - `pip3 install -r requirements.txt`
+
+## Subsequent runs:
+- Activate virtual environment
+    - macOS/Linux: `source env/bin/activate`
+    - Windows: `env\Scripts\activate.bat`
+
+## Run project
+- `python3 -m src`

--- a/test/python-bdk.spec.js
+++ b/test/python-bdk.spec.js
@@ -4,7 +4,7 @@ const path = require('path')
 const fs = require('fs')
 const forge = require('node-forge')
 
-const BASE_PYTHON = 'python'
+const BASE_PYTHON = 'src'
 const BASE_RESOURCE = 'resources'
 
 const BASE_STATIC = BASE_RESOURCE + '/static'
@@ -34,7 +34,7 @@ describe('Python BDK', () => {
         assert.file([
           path.join(BASE_PYTHON, 'activities.py'),
           path.join(BASE_PYTHON, 'gif_activities.py'),
-          path.join(BASE_RESOURCE, 'gif.xml')]);
+          path.join(BASE_RESOURCE, 'gif.jinja2')]);
       })
   })
 
@@ -71,13 +71,13 @@ describe('Python BDK', () => {
 
 function assertCommonFilesGenerated(dir) {
   assert.file([
-    path.join(BASE_PYTHON, 'main.py'),
+    path.join(BASE_PYTHON, '__main__.py'),
     path.join(BASE_RESOURCE, 'config.yaml'),
     path.join(BASE_RESOURCE, 'all_symphony_certs.pem'),
+    path.join(BASE_RESOURCE, 'logging.conf'),
     'rsa/privatekey.pem',
     'rsa/publickey.pem',
     'requirements.txt',
-    'logging.conf',
     '.gitignore'
   ]);
 


### PR DESCRIPTION
### Ticket
PLAT-10828

### Description
- Changed code root from `python` to `src` to enable VS Code module/package auto-detection
- Revised local imports to use relative path
- Renamed `main.py` to `__main.py__` to simplify launch to `python -m src`
- Changed from `os` to `pathlib` to simplify local relative path file/template loading
- Added `.gitignore` entries for env, bdk.log, datafeed.id and **/__pycache__
- Added readme with instructions for virtual env and launching
- Added virtual env creation to install script

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [N/A] Public functions properly commented
