### PR TITLE
PLAT-11351: Removed mention of beta after Python BDK 2.0.0 release

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -70,7 +70,7 @@ module.exports = class extends Generator {
             value: 'java'
           },
           {
-            name: 'Python (beta)',
+            name: 'Python',
             value: 'python'
           }
         ]


### PR DESCRIPTION
### Ticket
PLAT-11351

### Description
 Removed mention of beta after Python BDK 2.0.0 release

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [N/A] Public functions properly commented
