### PR TITLE
PLAT-11360: Bump minor version after creation of 2.0-rc branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-symphony",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/SymphonyPlatformSolutions/generator-symphony.git"


### PR DESCRIPTION
Since we want to deliver a 2.0.0 version, a 2.0-rc branch has been created.
Consequently, version has been bumped to 2.1.0 on master branch to stay consistent

### Ticket
PLAT-11360

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [N/A] Public functions properly commented
