### PR TITLE
Removed mavenLocal() from build.gradle

### DIFF
--- a/generators/workflow/templates/build.gradle
+++ b/generators/workflow/templates/build.gradle
@@ -9,7 +9,6 @@ java {
 }
 
 repositories {
-  mavenLocal()
   mavenCentral()
   maven {
     url "https://oss.sonatype.org/content/repositories/snapshots"


### PR DESCRIPTION
### Ticket
[PLAT-11325](https://perzoinc.atlassian.net/browse/PLAT-11325)

### Description
mavenLocal() was used in build.gradle for local test and it should not be used.