### PR TITLE
Automatically fetch latest version of BDKs

### DIFF
--- a/generators/python/index.js
+++ b/generators/python/index.js
@@ -27,7 +27,7 @@ module.exports = class extends Generator {
 
     await _getVersion().then(response => {
       if (response === undefined) {
-        console.log(`Failed to fetch latest Python BDK version from Maven Central, ${this.answers.bdkVersion} will be used.`);
+        console.log(`Failed to fetch latest Python BDK version from Pypi, ${this.answers.bdkVersion} will be used.`);
       } else {
         this.answers.bdkVersion = response['info']['version'];
       }

--- a/generators/python/index.js
+++ b/generators/python/index.js
@@ -1,6 +1,7 @@
 const Generator = require('yeoman-generator');
 const keyPair = require('../_lib/rsa').keyPair;
 const path = require('path');
+const axios = require("axios");
 
 const KEY_PAIR_LENGTH = 'KEY_PAIR_LENGTH';
 const BDK_VERSION_DEFAULT = '2.0.0';
@@ -11,6 +12,11 @@ const COMMON_EXT_APP_TEMPLATES = COMMON_TEMPLATE_FOLDER + '/circle-of-trust-ext-
 const RESOURCES_FOLDER = 'resources' // target resources folder
 const PYTHON_FOLDER = 'src' // target folder containing python sources
 
+const _getVersion = () => {
+  return axios.get('https://pypi.org/pypi/symphony-bdk-python/json')
+    .then(res =>  res.data)
+    .catch(err => {});
+}
 
 module.exports = class extends Generator {
 
@@ -18,6 +24,14 @@ module.exports = class extends Generator {
     this.answers = this.options;
     this.answers.bdkVersion = BDK_VERSION_DEFAULT;
     this.answers.trustStorePath = RESOURCES_FOLDER + '/all_symphony_certs.pem';
+
+    await _getVersion().then(response => {
+      if (response === undefined) {
+        console.log(`Failed to fetch latest Python BDK version from Maven Central, ${this.answers.bdkVersion} will be used.`);
+      } else {
+        this.answers.bdkVersion = response['info']['version'];
+      }
+    });
 
     this._generateRsaKeys();
     this._generateCommonFiles();

--- a/test/java-bdk.spec.js
+++ b/test/java-bdk.spec.js
@@ -11,10 +11,20 @@ const PACKAGE_DIR = 'com/mycompany/bot'
 
 const SMALL_KEY_PAIR_LENGTH = 512;
 
+const axios = require("axios");
+jest.mock('axios');
+
 describe('Java BDK', () => {
   const currentDir = process.cwd()
 
-  afterAll(() => process.chdir(currentDir))
+  beforeAll(() => {
+    axios.get.mockResolvedValue({"data": {"response": {"docs": [{"latestVersion": "2.3.0"}]}}});
+  })
+
+  afterAll(() => {
+    process.chdir(currentDir);
+    jest.resetAllMocks();
+  })
 
   it('Generate 2.0 spring boot gradle', () => {
     return helpers.run(path.join(__dirname, '../generators/app'))

--- a/test/python-bdk.spec.js
+++ b/test/python-bdk.spec.js
@@ -12,10 +12,20 @@ const BASE_SCRIPTS = BASE_STATIC + '/scripts'
 
 const SMALL_KEY_PAIR_LENGTH = 512;
 
+const axios = require("axios");
+jest.mock('axios');
+
 describe('Python BDK', () => {
   const currentDir = process.cwd()
 
-  afterAll(() => process.chdir(currentDir))
+  beforeAll(() => {
+    axios.get.mockResolvedValue({"data": {"info": {"version": "2.3.0"}}});
+  })
+
+  afterAll(() => {
+    process.chdir(currentDir);
+    jest.resetAllMocks();
+  })
 
   it('Generate 2.0 python bot', () => {
     return helpers.run(path.join(__dirname, '../generators/app'))


### PR DESCRIPTION
### Ticket
[PLAT-11465](https://perzoinc.atlassian.net/browse/PLAT-11465)

### Description
In this PR, we target maven central and PyPi apis  to get latest version of BDK and make use of them. If an error happens, the version hardcoded in index.js is used.

Endpoint used for Maven Central: http://search.maven.org/solrsearch/select?q=g:org.finos.symphony.bdk
Endpoint used for PyPi: https://pypi.org/pypi/symphony-bdk-python/json
