### PR TITLE
PLAT-11504: Generator to automatically fetch WDK latest version

### DIFF
--- a/generators/workflow/templates/build.gradle.ejs
+++ b/generators/workflow/templates/build.gradle.ejs
@@ -24,16 +24,17 @@ configurations {
 
 dependencies {
   // this will be provided by the workflow-bot application at runtime
-  compileOnly 'org.finos.symphony.wdk:workflow-language:0.0.1-SNAPSHOT'
+  compileOnly 'org.finos.symphony.wdk:workflow-language:<%= wdkVersion -%>'
 
   implementation 'org.apache.commons:commons-text:1.9'
 
   // used to download the standalone WDK bot jar
-  botJar 'org.finos.symphony.wdk:workflow-bot-app:0.0.1-SNAPSHOT'
+  botJar 'org.finos.symphony.wdk:workflow-bot-app:<%= wdkVersion -%>:boot'
 }
 
 tasks.register('botJar', Copy) {
   description "Downloads WDK jar."
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   from configurations.botJar
   into project.projectDir
   rename { f -> "workflow-bot-app.jar" }

--- a/test/workflow.spec.js
+++ b/test/workflow.spec.js
@@ -3,6 +3,8 @@ const assert = require('yeoman-assert')
 const path = require('path')
 const fs = require('fs')
 const {assertKeyPair} = require('./test-utils')
+const axios = require("axios");
+jest.mock('axios');
 
 
 const SMALL_KEY_PAIR_LENGTH = 512;
@@ -10,7 +12,14 @@ const SMALL_KEY_PAIR_LENGTH = 512;
 describe('Workflow bot', () => {
   const currentDir = process.cwd()
 
-  afterAll(() => process.chdir(currentDir))
+  beforeAll(() => {
+    axios.get.mockResolvedValue({"data": {"response": {"docs": [{"latestVersion": "0.0.6-SNAPSHOT"}]}}});
+  })
+
+  afterAll(() => {
+    process.chdir(currentDir);
+    jest.resetAllMocks();
+  })
 
   it('Generate workflow bot', () => {
     return helpers.run(path.join(__dirname, '../generators/app'))


### PR DESCRIPTION
### Ticket
[PLAT-11504](https://perzoinc.atlassian.net/browse/PLAT-11504)

### Description
In this commit, we made generator automatically fetch WDK latest version from Maven repository. We assume that both modules workflow-bot-app and workflow-language use the same version and are released together. Otherwise if this changes, then we would need to parse the api response to get the version for each module.
For the same occasion, we updated the generated build.gradle file for WDK to use DuplicatesStrategy.EXCLUDE to manage duplicated jar after download, and added maven classifier -boot- as suffix for workflow-bot-app version.
